### PR TITLE
minor improvement of the domain edges

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function interpolate(t, order, points, knots, weights, result) {
 
   var domain = [
     order-1,
-    knots.length-1 - (order-1)
+    knots.length - order
   ];
 
   // remap t to the domain where the spline is defined


### PR DESCRIPTION
The only thing this PR does is remove some superfluous computation when determining the edges of the domain, reducing a case of `x-1-(y-1)` to `x-y`. Tests still pass with this change (which makes sense, but it's good that they do =)
