### PR TITLE
Clamp t between [0,1]

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 
 
 function interpolate(t, degree, points, knots, weights, result) {
-
+  if ((t < 0) || (t > 1)) {
+    throw new Error('t out of bounds [0,1]: ' + t);
+  }
   var i,j,s,l;              // function-scoped iteration variables
   var n = points.length;    // points count
   var d = points[0].length; // point dimensionality
@@ -36,8 +38,8 @@ function interpolate(t, degree, points, knots, weights, result) {
   var low  = knots[domain[0]];
   var high = knots[domain[1]];
   t = t * (high - low) + low;
-
-  if(t < low || t > high) throw new Error('out of bounds');
+  t = Math.max(t, low);
+  t = Math.min(t, high);
 
   // find s (the spline segment) for the [t] value provided
   for(s=domain[0]; s<domain[1]; s++) {

--- a/test/index.js
+++ b/test/index.js
@@ -158,3 +158,21 @@ expected = [
 ];
 
 verify("weight-boosted non-uniform rational b-spline test", tvalues, points, expected, degree, knots, weights);
+
+points = [
+  [-1474.835381364233, 415.9551663966194],
+  [-1327.028226774942, 395.7560574947311],
+  [-1179.221072185651, 375.5569485928427]
+];
+knots = [ -418.7205814904043,
+  -418.7205814904043,
+  -418.7205814904043,
+  -120.3586453811225,
+  -120.3586453811225,
+  -120.3586453811225
+];
+degree = 2;
+expected = [
+  [-1179.221072185651, 375.5569485928427]
+];
+verify("floating point bounds error", [1.0], points, expected, degree, knots)


### PR DESCRIPTION
I have a case where a floating point precision error generates an 'out of bounds' error. This is from a user of my dxf library (https://github.com/bjnortier/dxf), which uses b-spline to interpolate DXF splines.

Using the parameters in the example I added to test/index.js, when t = 1.0, remapped t and high are:
```
t -120.35864538112247
high -120.3586453811225
```
which then generates an error. My proposal in this pull request is to move the bounds check to the beginning of the function (0 <= t <= 1.0), and then clamping the remapped t between "high" and "low".
