### PR TITLE
Updated README docs about closed curves

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ var points = [
   [ 0.5, -0.5],
   [ 1.0,  0.0],
 
+  // repeat the first `degree + 1` points
   [-1.0,  0.0],
   [-0.5,  0.5],
   [ 0.5, -0.5]
@@ -112,8 +113,21 @@ var knots = [
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9
 ];
 
+/*
+Disclaimer: If you are using a unclamped knot vector
+with closed curves, you may want to remap the t value
+to properly loop the curve.
+
+To do that, remap t value from [0.0, 1.0] to
+[0.0, 1.0 - 1.0 / (n + 1)] where 'n' is the number of
+the original control points used (discard the last repeated points).
+
+In this case, the number of points is 4 (discarded the last 3 points)
+*/
+var maxT = 1.0 / (points.length - (degree + 1));
+
 for(var t=0; t<1; t+=0.01) {
-  var point = bspline(t, degree, points, knots);
+  var point = bspline(t * maxT, degree, points, knots);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ the original control points used (discard the last repeated points).
 
 In this case, the number of points is 4 (discarded the last 3 points)
 */
-var maxT = 1.0 / (points.length - (degree + 1));
+var maxT = 1.0 - 1.0 / (points.length - (degree + 1));
 
 for(var t=0; t<1; t+=0.01) {
   var point = bspline(t * maxT, degree, points, knots);

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ var points = [
 ];
 
 var degree = 2;
+// The number of control points without the last repeated
+// points
+var originalNumPoints = points.length - (degree + 1);
 
 // and using an unclamped knot vector
 
@@ -124,7 +127,7 @@ the original control points used (discard the last repeated points).
 
 In this case, the number of points is 4 (discarded the last 3 points)
 */
-var maxT = 1.0 - 1.0 / (points.length - (degree + 1));
+var maxT = 1.0 - 1.0 / (originalNumPoints + 1);
 
 for(var t=0; t<1; t+=0.01) {
   var point = bspline(t * maxT, degree, points, knots);


### PR DESCRIPTION
This closes #15 

After some testing with this javascript module, I noticed that when using closed curves with unclamped knot vector, the spline don't loop perfectly near t=1, as showed in this video:

https://user-images.githubusercontent.com/43936806/125803874-056991ee-7972-4820-901b-92cbf10eed96.mp4

The fix is to remap t value from [0,1] to [0,1 - 1 / (n + 1)] (n being the number of control points without the last repeated points).
So I updated the closed curve example using this fix.

https://user-images.githubusercontent.com/43936806/125804620-1bb235fb-3e87-4e41-a8a9-a05499ccd26b.mp4