### PR TITLE
Update readme to fix clamped floating point issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ var knots = [
   0, 0, 0, 1, 2, 2, 2
 ];
 
-for(var t=0; t<1; t+=0.01) {
-  var point = bspline(t, degree, points, knots);
+// To ensure that the final clamped end is reached, avoid incrementing by floating point numbers
+for(var t=0; t<=100; t+=1) {
+  var point = bspline(t/100, degree, points, knots);
 }
 ```
 


### PR DESCRIPTION
Just for anyone who ran into this issue, I was using the docs as a reference for this package (which is nice + simple to use with clear explanation + diagrams, thanks!) and ran into the issue that I was using a clamped knot vector to force the first/last curve points to exactly match the control points, BUT initially the final control point wasn't actually being included when I used the iteration loop as per the docs.

Turns out it's because the doc example was incrementing by 0.01 in the interpolation loop, but because of the numeric representation in JS, adding 0.01 100 times does NOT result in 1 ! (it's like 0.999). Because of this the last point (which would have been when t === 1) was not actually being hit.

For anyone that runs into this issue, just interpolate across an integer range (like 0 < t <= 100) and then /100 for the bspline funcs.

Hope that helps someone :)